### PR TITLE
fix when course's name contains a space

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -767,7 +767,7 @@ class enrol_voot_plugin extends enrol_plugin {
 		$courseid = $groupprefix . $courseid;
 	}
 
-	$url = $this->get_config('vootproto') . "://" . $this->get_config('voothost') . $this->get_config('urlprefix') . "/people/@me/" . $courseid;
+	$url = $this->get_config('vootproto') . "://" . $this->get_config('voothost') . $this->get_config('urlprefix') . "/people/@me/" . urlencode($courseid);
 	$pagecontent = $this->getSslPage($url, $this->get_config('vootuser'), $this->get_config('vootpass'));
 
 	$members = json_decode($pagecontent);


### PR DESCRIPTION
You need to protect the course name (encode) when you create the url to reference it.
For example: if the course's name includes a space, the resulting url turns out to be invalid.
